### PR TITLE
Fix invalid name of k8s secret and change dump filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The below table lists all of the Environment Variables that are configurable for
 | TARGET_DATABASE_NAMES       | **(Required)** Name of the databases to dump. This should be comma seperated (e.g. `database1,database2`).       |
 | TARGET_DATABASE_USER        | **(Required)** Username to authenticate to the database with.                                                    |
 | TARGET_DATABASE_PASSWORD    | **(Required)** Password to authenticate to the database with. Should be configured using a Secret in Kubernetes. |
+| BACKUP_TIMESTAMP            | **(Required)** FORMAT of [date](http://man7.org/linux/man-pages/man1/date.1.html) which added to dump filename. Emty string if no need.                                                                                                                          |
 | SLACK_ENABLED               | **(Optional)** (true/false) Enable or disable the Slack Integration (Default False).                             |
 | SLACK_USERNAME              | **(Optional)** (true/false) Username to use for the Slack Integration (Default: kubernetes-s3-mysql-backup).            |
 | SLACK_CHANNEL               | **(Required if Slack enabled)** Slack Channel the WebHook is configured for.                                     |
@@ -125,6 +126,8 @@ spec:
                    secretKeyRef:
                      name: my-database-backup
                      key: database_password
+              - name: BACKUP_TIMESTAMP
+                value: "_%Y_%m_%d"
               - name: SLACK_ENABLED
                 value: "<true/false>"
               - name: SLACK_CHANNEL

--- a/README.md
+++ b/README.md
@@ -77,25 +77,11 @@ An example of how to schedule this container in Kubernetes as a cronjob is below
 apiVersion: v1
 kind: Secret
 metadata:
-  name: AWS_SECRET_ACCESS_KEY
+  name: my-database-backup
 type: Opaque
 data:
   aws_secret_access_key: <AWS Secret Access Key>
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: TARGET_DATABASE_PASSWORD
-type: Opaque
-data:
   database_password: <Your Database Password>
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: SLACK_WEBHOOK_URL
-type: Opaque
-data:
   slack_webhook_url: <Your Slack WebHook URL>
 ---
 apiVersion: batch/v1beta1
@@ -118,7 +104,7 @@ spec:
               - name: AWS_SECRET_ACCESS_KEY
                 valueFrom:
                    secretKeyRef:
-                     name: AWS_SECRET_ACCESS_KEY
+                     name: my-database-backup
                      key: aws_secret_access_key
               - name: AWS_DEFAULT_REGION
                 value: "<Your S3 Bucket Region>"
@@ -137,7 +123,7 @@ spec:
               - name: TARGET_DATABASE_PASSWORD
                 valueFrom:
                    secretKeyRef:
-                     name: TARGET_DATABASE_PASSWORD
+                     name: my-database-backup
                      key: database_password
               - name: SLACK_ENABLED
                 value: "<true/false>"
@@ -146,7 +132,7 @@ spec:
               - name: SLACK_WEBHOOK_URL
                 valueFrom:
                    secretKeyRef:
-                     name: SLACK_WEBHOOK_URL
+                     name: my-database-backup
                      key: slack_webhook_url
           restartPolicy: Never
 ```

--- a/resources/perform-backup.sh
+++ b/resources/perform-backup.sh
@@ -9,14 +9,15 @@ has_failed=false
 for CURRENT_DATABASE in ${TARGET_DATABASE_NAMES//,/ }
 do
 
+    DUMP=$CURRENT_DATABASE`date +$BACKUP_TIMESTAMP`.sql
     # Perform the database backup. Put the output to a variable. If successful upload the backup to S3, if unsuccessful print an entry to the console and the log, and set has_failed to true.
-    if sqloutput=$(mysqldump -u $TARGET_DATABASE_USER -h $TARGET_DATABASE_HOST -p$TARGET_DATABASE_PASSWORD -P $TARGET_DATABASE_PORT $CURRENT_DATABASE 2>&1 > /tmp/$CURRENT_DATABASE.sql)
+    if sqloutput=$(mysqldump -u $TARGET_DATABASE_USER -h $TARGET_DATABASE_HOST -p$TARGET_DATABASE_PASSWORD -P $TARGET_DATABASE_PORT $CURRENT_DATABASE 2>&1 > /tmp/$DUMP)
     then
-        
+
         echo -e "Database backup successfully completed for $CURRENT_DATABASE at $(date +'%d-%m-%Y %H:%M:%S')."
 
         # Perform the upload to S3. Put the output to a variable. If successful, print an entry to the console and the log. If unsuccessful, set has_failed to true and print an entry to the console and the log
-        if awsoutput=$(aws s3 cp /tmp/$CURRENT_DATABASE.sql s3://$AWS_BUCKET_NAME$AWS_BUCKET_BACKUP_PATH/$CURRENT_DATABASE.sql 2>&1)
+        if awsoutput=$(aws s3 cp /tmp/$DUMP s3://$AWS_BUCKET_NAME$AWS_BUCKET_BACKUP_PATH/$DUMP 2>&1)
         then
             echo -e "Database backup successfully uploaded for $CURRENT_DATABASE at $(date +'%d-%m-%Y %H:%M:%S')."
         else
@@ -59,5 +60,5 @@ else
     fi
 
     exit 0
-    
+
 fi


### PR DESCRIPTION
1) Seems Use upper case is not allowed for kubernetes secret name.
The Secret "AWS_SECRET_ACCESS_KEY" is invalid: metadata.name: Invalid value: "AWS_SECRET_ACCESS_KEY": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
2) dump filename should consist  timespamp
* to do not overwrite old one 
* e.g. gitlab backup which is created by their native backup command 1565092253_2019_08_06_11.11.0-ee_gitlab_backup.tar
