### PR TITLE
Bump Alpine Linux and Google Cloud SDK version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image
-FROM alpine:3.11
+FROM alpine:3.12.1
 
 RUN apk -v --update add \
         python3 \
@@ -24,7 +24,7 @@ RUN apk -v --update add \
 ENV TARGET_DATABASE_PORT=3306
 ENV SLACK_ENABLED=false
 ENV SLACK_USERNAME=kubernetes-s3-mysql-backup
-ENV CLOUD_SDK_VERSION=285.0.1
+ENV CLOUD_SDK_VERSION=319.0.0
 ENV BACKUP_PROVIDER=aws
 
 # Set Google Cloud SDK Path


### PR DESCRIPTION
This PR bumps Alpine Linux to 3.12.1 and gcloud to 319.0.0