### PR TITLE
Switch to workflow_dispatch trigger for tests

### DIFF
--- a/.github/workflows/FAILURE.md
+++ b/.github/workflows/FAILURE.md
@@ -1,1 +1,0 @@
-:no_entry_sign: Some tests failed. See [run](https://github.com/benjamin-maynard/kubernetes-cloud-mysql-backup/actions/runs/{workflow_id}) for more details :poop:

--- a/.github/workflows/SUCCESS.md
+++ b/.github/workflows/SUCCESS.md
@@ -1,1 +1,0 @@
-:white_check_mark: All tests successfully passed. See [run](https://github.com/benjamin-maynard/kubernetes-cloud-mysql-backup/actions/runs/{workflow_id}) for more details :fire:

--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -1,24 +1,29 @@
-name: Runs tests on a PR
-on: 
-  issue_comment:
-    types: [created]
+name: Run tests on a PR
+on:
+  workflow_dispatch:
+    inputs:
+      prID:
+        description: 'The ID of the Pull Request to test'
+        required: true
 jobs:
   test-pr:
     runs-on: ubuntu-18.04
     steps:
       -
-        name: Exit if not a PR comment
-        if: ${{ !github.event.issue.pull_request }}
+        name: Get PR Info for Tests
+        id: get-pr-info
         run: |
-          exit 1
-      -
-        name: Determine if there is authority to continue
-        if: ${{ github.event.comment.user.login != 'benjamin-maynard' || github.event.comment.body  != '[Run PR Tests]' }}
-        run: |
-          exit 1
+          PRINFO=$(curl -H "Accept: application/vnd.github.v3+json"   https://api.github.com/repos/benjamin-maynard/kubernetes-cloud-mysql-backup/pulls/${{ github.event.inputs.prID }})
+          PRHEAD=$(echo $PRINFO | jq -r .head.repo.full_name)
+          PRSHA=$(echo $PRINFO | jq -r .head.sha)
+          echo "::set-output name=PRHEAD::$PRHEAD"
+          echo "::set-output name=PRSHA::$PRSHA"
       -
         name: Checkout
         uses: actions/checkout@v2
+        with:
+          repository: ${{ steps.get-pr-info.outputs.PRHEAD }}
+          ref: ${{ steps.get-pr-info.outputs.PRSHA }}
       - 
         name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@master
@@ -425,17 +430,11 @@ jobs:
           rm /tmp/world.sql
           rm /tmp/world.sql.age
       -
-        name: Comment on PR with Successful
-        uses: benjamin-maynard/comment-on-pr@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          filename: .github/workflows/SUCCESS.md
+        name: Comment on PR with Success
+        run: |
+          curl -X POST -H "Accept: application/vnd.github.v3+json" -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/benjamin-maynard/kubernetes-cloud-mysql-backup/issues/${{ github.event.inputs.prID }})/comments -d '{"body":":white_check_mark: All tests passed successfully. Please see the [Github Actions Run](https://github.com/benjamin-maynard/kubernetes-cloud-mysql-backup/actions/runs/${{ github.run_id }}) for more details.\n\n**Note:** Tests are performed using the latest [pr-tests.yaml](https://github.com/benjamin-maynard/kubernetes-cloud-mysql-backup/blob/master/.github/workflows/run-pr-tests.yaml) config as defined in the HEAD of the master branch. If this PR includes modified set of tests they have not been executed."}'
       -
         name: Comment on PR with Failure
-        uses: benjamin-maynard/comment-on-pr@master
         if: ${{ failure() }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          filename: .github/workflows/FAILURE.md
+        run: |
+          curl -X POST -H "Accept: application/vnd.github.v3+json" -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/benjamin-maynard/kubernetes-cloud-mysql-backup/issues/${{ github.event.inputs.prID }})/comments -d '{"body":":x: Tests did not complete successfully. Please see the [Github Actions Run](https://github.com/benjamin-maynard/kubernetes-cloud-mysql-backup/actions/runs/${{ github.run_id }}) for more details.\n\n**Note:** Tests are performed using the latest [pr-tests.yaml](https://github.com/benjamin-maynard/kubernetes-cloud-mysql-backup/blob/master/.github/workflows/run-pr-tests.yaml) config as defined in the HEAD of the master branch. If this PR includes modified set of tests they have not been executed."}'


### PR DESCRIPTION
This PR fixes the PR tests and switches from the `pull_request` trigger to a `workflow_dispatch` trigger.