### PR TITLE
Fix build issue with six upgrade due to pre-installed system dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk -v --update add \
     gzip \
     go \
     git && \
-    pip3 install --upgrade six awscli s3cmd python-magic && \
+    pip3 install --upgrade awscli s3cmd python-magic && \
     rm /var/cache/apk/*
 
 # Set Default Environment Variables


### PR DESCRIPTION
This PR fixes an issue with six that was causing a build failure due to it being a pre-installed system dependency.