### PR TITLE
Fix PR test failure due to varying client versions

### DIFF
--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -89,6 +89,9 @@ jobs:
           # Strip the "Dump Completed on" line
           echo "Stripping Dump Completed On line from downloaded backup..."
           sed -i '/-- Dump completed on/d' /tmp/world.sql
+          # Strip the "MariaDB dump" line
+          echo "Stripping MariaDB dump line from downloaded backup..."
+          sed -i '/-- MariaDB dump/d' /tmp/world.sql
           # Compare the database backups, diff will exit with 1 if the files do not match causing the workflow to fail
           echo "Comparing database backup to known good database..."
           diff tests/db/world.sql /tmp/world.sql

--- a/tests/db/world.sql
+++ b/tests/db/world.sql
@@ -1,4 +1,3 @@
--- MariaDB dump 10.17  Distrib 10.4.15-MariaDB, for Linux (x86_64)
 --
 -- Host: db-server    Database: world
 -- ------------------------------------------------------


### PR DESCRIPTION
PR tests were failing as the mysql client version is listed in the DB dump that was used for comparison. This PR strips this line from the comparison.