### PR TITLE
Change latest tagging behaviour to tag latest for releases instead of commits to master

### DIFF
--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -32,4 +32,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ghcr.io/benjamin-maynard/kubernetes-cloud-mysql-backup:latest,ghcr.io/benjamin-maynard/kubernetes-cloud-mysql-backup:${{ github.sha }}
+          tags: ghcr.io/benjamin-maynard/kubernetes-cloud-mysql-backup:latest-master,ghcr.io/benjamin-maynard/kubernetes-cloud-mysql-backup:${{ github.sha }}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -32,4 +32,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ghcr.io/benjamin-maynard/kubernetes-cloud-mysql-backup:${{ steps.get_version.outputs.VERSION }}
+          tags: ghcr.io/benjamin-maynard/kubernetes-cloud-mysql-backup:latest,ghcr.io/benjamin-maynard/kubernetes-cloud-mysql-backup:${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
Tag each release as `latest` rather than each commit to master , move commits to master to `latest-master` tag.