### PR TITLE
Fix error when both TARGET_DATABASE_NAMES and TARGET_ALL_DATABASES are true

### DIFF
--- a/resources/perform-backup.sh
+++ b/resources/perform-backup.sh
@@ -26,6 +26,9 @@ else
 fi
 
 if [ "$TARGET_ALL_DATABASES" = "true" ]; then
+    # Ignore any databases specified by TARGET_DATABASE_NAMES
+    TARGET_DATABASE_NAMES=""
+    # Build Database List
     ALL_DATABASES_EXCLUSION_LIST="'mysql','sys','tmp','information_schema','performance_schema'"
     ALL_DATABASES_SQLSTMT="SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN (${ALL_DATABASES_EXCLUSION_LIST})"
     if ! ALL_DATABASES_DATABASE_LIST=`mysql -u $TARGET_DATABASE_USER -h $TARGET_DATABASE_HOST -p$TARGET_DATABASE_PASSWORD -P $TARGET_DATABASE_PORT -ANe"${ALL_DATABASES_SQLSTMT}"`

--- a/resources/perform-backup.sh
+++ b/resources/perform-backup.sh
@@ -27,7 +27,11 @@ fi
 
 if [ "$TARGET_ALL_DATABASES" = "true" ]; then
     # Ignore any databases specified by TARGET_DATABASE_NAMES
-    TARGET_DATABASE_NAMES=""
+    if [ ! -z "$TARGET_DATABASE_NAMES" ]
+    then
+        echo "Both TARGET_ALL_DATABASES is set to 'true' and databases are manually specified by 'TARGET_DATABASE_NAMES'. Ignoring 'TARGET_DATABASE_NAMES'..."
+        TARGET_DATABASE_NAMES=""
+    fi
     # Build Database List
     ALL_DATABASES_EXCLUSION_LIST="'mysql','sys','tmp','information_schema','performance_schema'"
     ALL_DATABASES_SQLSTMT="SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN (${ALL_DATABASES_EXCLUSION_LIST})"


### PR DESCRIPTION
This PR fixes a logic error when databases are manually listed in `TARGET_DATABASE_NAMES` and `TARGET_ALL_DATABASES` is set to true. This was introduced by #37.

This PR unsets `TARGET_DATABASE_NAMES` if `TARGET_ALL_DATABASES` is true and adds a log entry.