### PR TITLE
Add AWS DUMP_ALL_DATABASES tests and fix paths

### DIFF
--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -103,10 +103,10 @@ jobs:
         run: |
           # Perform database backup
           echo "Performing database backup..."
-          docker run -e GCP_GCLOUD_AUTH=${{ secrets.GCP_SA }} -e GCP_BUCKET_BACKUP_PATH="/${{ github.sha }}" -e TARGET_ALL_DATABASES="true" --env-file tests/configs/gcp.env --network backup-net kubernetes-cloud-mysql-backup:test
+          docker run -e GCP_GCLOUD_AUTH=${{ secrets.GCP_SA }} -e GCP_BUCKET_BACKUP_PATH="/${{ github.sha }}/dumpall" -e TARGET_ALL_DATABASES="true" --env-file tests/configs/gcp.env --network backup-net kubernetes-cloud-mysql-backup:test
           # Fetch backup file from GCS
           echo "Fetching database backup..."
-          gsutil cp gs://kubernetes-cloud-mysql-backup-github-testing/${{ github.sha }}/world.sql /tmp/world.sql
+          gsutil cp gs://kubernetes-cloud-mysql-backup-github-testing/${{ github.sha }}/dumpall/world.sql /tmp/world.sql
           # Strip the "Dump Completed on" line
           echo "Stripping Dump Completed On line from downloaded backup..."
           sed -i '/-- Dump completed on/d' /tmp/world.sql
@@ -304,6 +304,27 @@ jobs:
           # Fetch backup file from GCS
           echo "Fetching database backup..."
           aws s3 cp s3://kubernetes-cloud-mysql-backup-github-testing/${{ github.sha }}/world.sql /tmp/world.sql
+          # Strip the "Dump Completed on" line
+          echo "Stripping Dump Completed On line from downloaded backup..."
+          sed -i '/-- Dump completed on/d' /tmp/world.sql
+          # Strip the "MariaDB dump" line
+          echo "Stripping MariaDB dump line from downloaded backup..."
+          sed -i '/-- MariaDB dump/d' /tmp/world.sql
+          # Compare the database backups, diff will exit with 1 if the files do not match causing the workflow to fail
+          echo "Comparing database backup to known good database..."
+          diff tests/db/world.sql /tmp/world.sql
+          # Remove /tmp/world.sql
+          echo "Removing /tmp/world.sql"
+          rm /tmp/world.sql
+      -
+        name: Test AWS Standard All Databases Backup
+        run: |
+          # Perform database backup
+          echo "Performing database backup..."
+          docker run -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_KEY }} -e AWS_BUCKET_BACKUP_PATH="/${{ github.sha }}/dumpall" -e TARGET_ALL_DATABASES="true" --env-file tests/configs/aws.env --network backup-net kubernetes-cloud-mysql-backup:test
+          # Fetch backup file from GCS
+          echo "Fetching database backup..."
+          aws s3 cp s3://kubernetes-cloud-mysql-backup-github-testing/${{ github.sha }}/dumpall/world.sql /tmp/world.sql
           # Strip the "Dump Completed on" line
           echo "Stripping Dump Completed On line from downloaded backup..."
           sed -i '/-- Dump completed on/d' /tmp/world.sql


### PR DESCRIPTION
This PR adds an AWS test for the DUMP_ALL_DATABASES option. It also configures the GCP and AWS tests to use a dedicated subdirectory for the backup storage on GCS and S3.