### PR TITLE
Feat: Added proxy URL environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ The below table lists all of the Environment Variables that are configurable for
 | SLACK_ENABLED                    | **(Optional)** (true/false) Enable or disable the Slack Integration (Default False).                                                                                                                                                                  |
 | SLACK_USERNAME                   | **(Optional)** (true/false) Username to use for the Slack Integration (Default: kubernetes-cloud-mysql-backup).                                                                                                                                       |
 | SLACK_CHANNEL                    | **(Required if Slack enabled)** Slack Channel the WebHook is configured for.                                                                                                                                                                          |
-| SLACK_PROXY                    | **(Required if Slack enabled)** Proxy URL if Slack your is behind proxy example 
-<[protocol://][user:password@]proxyhost[:port]>.                                                                                                                                                                         |
+| SLACK_PROXY                    | **(Required if Slack enabled)** Proxy URL if Slack your is behind proxy.                                                                                                                                                                         |
 | SLACK_WEBHOOK_URL                | **(Required if Slack enabled)** What is the Slack WebHook URL to post to? Should be configured using a Secret in Kubernetes.                                                                                                                          |
 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The below table lists all of the Environment Variables that are configurable for
 | SLACK_ENABLED                    | **(Optional)** (true/false) Enable or disable the Slack Integration (Default False).                                                                                                                                                                  |
 | SLACK_USERNAME                   | **(Optional)** (true/false) Username to use for the Slack Integration (Default: kubernetes-cloud-mysql-backup).                                                                                                                                       |
 | SLACK_CHANNEL                    | **(Required if Slack enabled)** Slack Channel the WebHook is configured for.                                                                                                                                                                          |
-| SLACK_PROXY                    | **(Required if Slack enabled)** Proxy URL if Slack your is behind proxy.                                                                                                                                                                         |
+| SLACK_PROXY                    | **(Required if Slack enabled)** Proxy URL if Slack is behind proxy.                                                                                                                                                                         |
 | SLACK_WEBHOOK_URL                | **(Required if Slack enabled)** What is the Slack WebHook URL to post to? Should be configured using a Secret in Kubernetes.                                                                                                                          |
 
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The below table lists all of the Environment Variables that are configurable for
 | SLACK_ENABLED                    | **(Optional)** (true/false) Enable or disable the Slack Integration (Default False).                                                                                                                                                                  |
 | SLACK_USERNAME                   | **(Optional)** (true/false) Username to use for the Slack Integration (Default: kubernetes-cloud-mysql-backup).                                                                                                                                       |
 | SLACK_CHANNEL                    | **(Required if Slack enabled)** Slack Channel the WebHook is configured for.                                                                                                                                                                          |
+| SLACK_PROXY                    | **(Required if Slack enabled)** Proxy URL if Slack your is behind proxy example 
+<[protocol://][user:password@]proxyhost[:port]>.                                                                                                                                                                         |
 | SLACK_WEBHOOK_URL                | **(Required if Slack enabled)** What is the Slack WebHook URL to post to? Should be configured using a Secret in Kubernetes.                                                                                                                          |
 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The below table lists all of the Environment Variables that are configurable for
 | SLACK_ENABLED                    | **(Optional)** (true/false) Enable or disable the Slack Integration (Default False).                                                                                                                                                                  |
 | SLACK_USERNAME                   | **(Optional)** (true/false) Username to use for the Slack Integration (Default: kubernetes-cloud-mysql-backup).                                                                                                                                       |
 | SLACK_CHANNEL                    | **(Required if Slack enabled)** Slack Channel the WebHook is configured for.                                                                                                                                                                          |
-| SLACK_PROXY                    | **(Required if Slack enabled)** Proxy URL if Slack is behind proxy.                                                                                                                                                                         |
+| SLACK_PROXY                    | **(Optional)** Proxy URL if Slack is behind proxy.                                                                                                                                                                         |
 | SLACK_WEBHOOK_URL                | **(Required if Slack enabled)** What is the Slack WebHook URL to post to? Should be configured using a Secret in Kubernetes.                                                                                                                          |
 
 

--- a/resources/slack-alert.sh
+++ b/resources/slack-alert.sh
@@ -10,4 +10,8 @@ PAYLOAD="payload={\"channel\": \"$SLACK_CHANNEL\", \"username\": \"$SLACK_USERNA
 fi
 
 # Send Slack message
-curl -s -X POST --data-urlencode "$PAYLOAD" "$SLACK_WEBHOOK_URL" > /dev/null
+if [ -n "$SLACK_PROXY" ]; then
+    curl -s --proxy $SLACK_PROXY -X POST --data-urlencode "$PAYLOAD" "$SLACK_WEBHOOK_URL" > /dev/null
+else
+    curl -s -X POST --data-urlencode "$PAYLOAD" "$SLACK_WEBHOOK_URL" > /dev/null
+fi


### PR DESCRIPTION
The pull request adds the feature of providing the proxy url. The environment may be behind the proxy and slack notifications may not work. The variable SLACK_PROXY is an option variable that if set will use the provided proxy address to send notifications. 